### PR TITLE
Include DNS as an option for fuzzing in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ afl-gcc
 afl-gotcpu
 afl-showmap
 afl-tmin
+aflnet-replay
+aflnet.o
 as
 
 # Binaries produced by "make -C llvm_mode"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ AFLNet adds the following options to AFL. Run ```afl-fuzz --help``` to see all o
 
 - ***-N netinfo***: server information (e.g., tcp://127.0.0.1/8554)
 
-- ***-P protocol***: application protocol to be tested (e.g., RTSP, FTP)
+- ***-P protocol***: application protocol to be tested (e.g., RTSP, FTP, DTLS12, DNS)
 
 - ***-D usec***: (optional) waiting time (in micro seconds) for the server to complete its initialization 
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -8059,7 +8059,7 @@ static void usage(u8* argv0) {
        "Settings for network protocol fuzzing (AFLNet):\n\n"
 
        "  -N netinfo    - server information (e.g., tcp://127.0.0.1/8554)\n"
-       "  -P protocol   - application protocol to be tested (e.g., RTSP, FTP, DTLS12)\n"
+       "  -P protocol   - application protocol to be tested (e.g., RTSP, FTP, DTLS12, DNS)\n"
        "  -D usec       - waiting time (in micro seconds) for the server to initialize\n"
        "  -W msec       - waiting time (in miliseconds) for receiving the first response to each input sent\n"
        "  -w usec       - waiting time (in micro seconds) for receiving follow-up responses\n"

--- a/tutorials/dnsmasq/README.md
+++ b/tutorials/dnsmasq/README.md
@@ -1,6 +1,6 @@
 # Tutorial - Fuzzing Dnsmasq server
 
-We assume that you have read the AFLNet README.md which includes a detailed tutorial for fuzzing Live555 RTSP server before reading this tutorial.
+This assumes that you have read the AFLNet README.md, which includes a detailed tutorial for fuzzing the Live555 RTSP server, before reading this tutorial.
 
 ## Step-0. Server compilation & setup
 
@@ -32,11 +32,11 @@ Once Dnsmasq has been successfully compiled, we can test the server by adding an
 # Add an address to resolve
 echo address=/test.com/5.5.5.5 | sudo tee -a /etc/dnsmasq.conf
 # Run Dnsmasq and don't daemonize (the dnsmasq.conf file will specify port 5353)
-./dnsmasq --no-daemon
+./dnsmasq
 ```
 
-Now we can use `dig` to qery the test.com domain:
-```bash
+Now we can use `dig` to query the test.com domain:
+```
 dig @127.0.0.1 -p 5353 test.com
 
 ; <<>> DiG 9.11.3-1ubuntu1.12-Ubuntu <<>> @127.0.0.1 -p 5353 test.com
@@ -66,7 +66,7 @@ Various DNS queries have been recorded and saved in the `aflnet/tutorials/dnsmas
 
 ```bash
 cd $WORKDIR/dnsmasq/src
-afl-fuzz -d -i $AFLNET/tutorials/dnsmasq/in-dns -o out-dns -N tcp://127.0.0.1/5353 -P DNS -D 10000 -K -R ./dnsmasq --no-daemon
+afl-fuzz -d -i $AFLNET/tutorials/dnsmasq/in-dns -o out-dns -N tcp://127.0.0.1/5353 -P DNS -D 10000 -K -R ./dnsmasq
 ```
 
 With this particular version of Dnsmasq (v2.73rc6), you should get a few crash after waiting long enough.

--- a/tutorials/dnsmasq/dnsmasq.conf
+++ b/tutorials/dnsmasq/dnsmasq.conf
@@ -9,6 +9,9 @@
 # leaving only DHCP and/or TFTP.
 port=5353
 
+# Do not daemonize
+no-daemon
+
 # The following two options make you a better netizen, since they
 # tell dnsmasq to filter out queries which the public DNS cannot
 # answer, and which load the servers (especially the root servers)


### PR DESCRIPTION
This is a minor change to fix a few things:

- Added `DTLS12` & `DNS` in the main README.md file as protocol options
- Added `DNS` as an option in the `afl-fuzz` help output
- Fixed typos in the DNS tutorial README.md
- Moved the `--no-daemon` option from the command line (in the DNS tutorial) to the `dnsmasq.conf` file
- Updated the `.gitignore` to include the `aflnet-replay` & `aflnet.o` files