### PR TITLE
Minor fixes

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1085,11 +1085,11 @@ HANDLE_RESPONSES:
 
   net_recv(sockfd, timeout, poll_wait_msecs, &response_buf, &response_buf_size);
 
-  if (messages_sent > 0) {
+  if (messages_sent > 0 && response_bytes != NULL) {
     response_bytes[messages_sent - 1] = response_buf_size;
   }
 
-  //wait a bit letting the server to complete its remaing task(s)
+  //wait a bit letting the server to complete its remaining task(s)
   memset(session_virgin_bits, 255, MAP_SIZE);
   while(1) {
     if (has_new_bits(session_virgin_bits) != 2) break;

--- a/aflnet.c
+++ b/aflnet.c
@@ -321,13 +321,13 @@ region_t* extract_requests_dicom(unsigned char* buf, unsigned int buf_size, unsi
   unsigned int byte_count = 0;
   while (byte_count < buf_size) {
 
-    if ((byte_count + 2 >= buf_size) || (byte_count + 5 >= buf_size)) break; 
-    
+    if ((byte_count + 2 >= buf_size) || (byte_count + 5 >= buf_size)) break;
+
     // Bytes from third to sixth encode the PDU length.
-    pdu_length = 
-      (buf[byte_count + 5]) | 
-      (buf[byte_count + 4] << 8)  | 
-      (buf[byte_count + 3] << 16) | 
+    pdu_length =
+      (buf[byte_count + 5]) |
+      (buf[byte_count + 4] << 8)  |
+      (buf[byte_count + 3] << 16) |
       (buf[byte_count + 2] << 24);
 
     // DICOM Header(6 bytes) includes PDU type and PDU length.
@@ -1281,8 +1281,9 @@ int net_recv(int sockfd, struct timeval timeout, int poll_w, char **response_buf
       }
       while (n > 0) {
         usleep(10);
-        *response_buf = (unsigned char *)ck_realloc(*response_buf, *len + n);
+        *response_buf = (unsigned char *)ck_realloc(*response_buf, *len + n + 1);
         memcpy(&(*response_buf)[*len], temp_buf, n);
+        (*response_buf)[(*len) + n] = '\0';
         *len = *len + n;
         n = recv(sockfd, temp_buf, sizeof(temp_buf), 0);
         if ((n < 0) && (errno != EAGAIN)) {


### PR DESCRIPTION
This PR addresses two crashes:
1) Line 1088 crashes AFLNet if the user wants to exit AFLNet and the iteration is still in the beginning with `response_bytes` uninitialized.
2) When `response_buf` is printed (e.g. for manual debugging purposes) extra memory is read.