### PR TITLE
Fix bug for aflnet-replay & afl-replay

### DIFF
--- a/afl-replay.c
+++ b/afl-replay.c
@@ -76,7 +76,7 @@ int main(int argc, char* argv[])
   usleep(server_wait_usecs);
 
   int sockfd;
-  if ((!strcmp(argv[2], "DTLS12")) || (!strcmp(argv[2], "SIP"))) {
+  if ((!strcmp(argv[2], "DTLS12")) || (!strcmp(argv[2], "DNS")) || (!strcmp(argv[2], "SIP"))) {
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
   } else {
     sockfd = socket(AF_INET, SOCK_STREAM, 0);

--- a/aflnet-replay.c
+++ b/aflnet-replay.c
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
   }
 
   int sockfd;
-  if ((!strcmp(argv[2], "DTLS12")) || (!strcmp(argv[2], "SIP"))) {
+  if ((!strcmp(argv[2], "DTLS12")) || (!strcmp(argv[2], "DNS")) || (!strcmp(argv[2], "SIP"))) {
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
   } else {
     sockfd = socket(AF_INET, SOCK_STREAM, 0);


### PR DESCRIPTION
Use SOCK_DGRAM(UDP) socket for replaying DNS protocol