### PR TITLE
Standardize response code extraction method names

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -9075,16 +9075,16 @@ int main(int argc, char** argv) {
           extract_response_codes = &extract_response_codes_tftp;
         }else if (!strcmp(optarg, "DHCP")) {
           extract_requests = &extract_requests_dhcp;
-          extract_response_codes = &extract_response_code_dhcp;
+          extract_response_codes = &extract_response_codes_dhcp;
         }else if (!strcmp(optarg, "SNTP")) {
           extract_requests = &extract_requests_SNTP;
-          extract_response_codes = &extract_response_code_SNTP;
+          extract_response_codes = &extract_response_codes_SNTP;
         }else if (!strcmp(optarg, "NTP")) {
           extract_requests = &extract_requests_NTP;
-          extract_response_codes = &extract_response_code_NTP;
+          extract_response_codes = &extract_response_codes_NTP;
         }else if (!strcmp(optarg, "SNMP")) {
           extract_requests = &extract_requests_SNMP;
-          extract_response_codes = &extract_response_code_SNMP;
+          extract_response_codes = &extract_response_codes_SNMP;
         } else {
           FATAL("%s protocol is not supported yet!", optarg);
         }

--- a/aflnet.c
+++ b/aflnet.c
@@ -1236,7 +1236,7 @@ unsigned int* extract_response_codes_tftp(unsigned char* buf, unsigned int buf_s
   return state_sequence;
 }
 
-unsigned int* extract_response_code_dhcp(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
+unsigned int* extract_response_codes_dhcp(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
 {
   char *mem;
   unsigned int byte_count = 0;
@@ -1297,7 +1297,7 @@ unsigned int* extract_response_code_dhcp(unsigned char* buf, unsigned int buf_si
   return state_sequence;
 }
 
-unsigned int* extract_response_code_SNTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
+unsigned int* extract_response_codes_SNTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
 {
   char *mem;
   unsigned int byte_count = 0;
@@ -1364,7 +1364,7 @@ unsigned int* extract_response_code_SNTP(unsigned char* buf, unsigned int buf_si
   return state_sequence;
 }
 
-unsigned int* extract_response_code_NTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
+unsigned int* extract_response_codes_NTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
 {
   char *mem;
   unsigned int byte_count = 0;
@@ -1431,7 +1431,7 @@ unsigned int* extract_response_code_NTP(unsigned char* buf, unsigned int buf_siz
 }
 
 
-unsigned int* extract_response_code_SNMP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
+unsigned int* extract_response_codes_SNMP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref)
 {
   char *mem;
   unsigned int byte_count = 0;

--- a/aflnet.h
+++ b/aflnet.h
@@ -69,11 +69,11 @@ unsigned int* extract_response_codes_dtls12(unsigned char* buf, unsigned int buf
 unsigned int* extract_response_codes_sip(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
 unsigned int* extract_response_codes_http(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
 unsigned int* extract_response_codes_ipp(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
-unsigned int* extract_response_code_dhcp(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
+unsigned int* extract_response_codes_dhcp(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
 unsigned int* extract_response_codes_tftp(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
-unsigned int* extract_response_code_SNTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
-unsigned int* extract_response_code_NTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
-unsigned int* extract_response_code_SNMP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
+unsigned int* extract_response_codes_SNTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
+unsigned int* extract_response_codes_NTP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
+unsigned int* extract_response_codes_SNMP(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
 extern unsigned int* (*extract_response_codes)(unsigned char* buf, unsigned int buf_size, unsigned int* state_count_ref);
 
 region_t* extract_requests_smtp(unsigned char* buf, unsigned int buf_size, unsigned int* region_count_ref);


### PR DESCRIPTION
Fix for #104.

This MR will fix the incorrect method names in aflnet-replay.c by standardizing response_codes to the plural form in all extractors.