### PR TITLE
- fixed double free error during the parsing of network config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get -y update && \
-    apt-get -y install sudo \ 
+    apt-get -y install sudo \
     apt-utils \
     build-essential \
     openssl \

--- a/aflnet.c
+++ b/aflnet.c
@@ -2623,10 +2623,6 @@ int parse_net_config(u8* net_config, u8* protocol, u8** ip_address, u32* port)
       *port = atoi(tokens[2]);
       if (*port == 0) return 1;
   } else return 1;
-
-  for (int i = 0; i < tokenCount; i++) {
-    free(tokens[i]);
-  }
   free(tokens);
   return 0;
 }


### PR DESCRIPTION
There was an error that made the start of aflnet impossible. The bug stated the error:

root@53a93a51c7e2:/shared# ./aflnet-fuzz -d -i in -o out -N tcp://127.0.0.1/1883 -P MQTT -D 10000 mosquitto
afl-fuzz 2.56b by <lcamtuf@google.com>
double free or corruption (out)
Aborted (core dumped)
----------
with stack trace:

(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007fe483c247f1 in __GI_abort () at abort.c:79
#2  0x00007fe483c6d837 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7fe483d9aa7b "%s\n") at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007fe483c748ba in malloc_printerr (str=str@entry=0x7fe483d9c788 "double free or corruption (out)") at malloc.c:5342
#4  0x00007fe483c7be4a in _int_free (have_lock=0, p=0x7ffde1ca4e10, av=0x7fe483fcfc40 <main_arena>) at malloc.c:4308
#5  __GI___libc_free (mem=mem@entry=0x7ffde1ca4e20) at malloc.c:3134
#6  0x0000558727a2e208 in parse_net_config (net_config=<optimized out>, protocol=0x558727d41adc <net_protocol> "", ip_address=<optimized out>, port=0x558727d41ad8 <net_port>) at aflnet.c:2628
#7  0x0000558727a04162 in main (argc=11, argv=0x7ffde1ca51d8) at afl-fuzz.c:9005
