### PR TITLE
Patch Underflowed pending favored

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7619,6 +7619,8 @@ abandon_entry:
     pending_not_fuzzed--;
     if (queue_cur->favored && (queue_cur->generating_state_id == target_state_id || queue_cur->is_initial_seed))
       pending_favored--;
+    else if (queue_cur->favored && queue_cur->generating_state_id != target_state_id)
+      pending_favored = (pending_favored > 0) ? pending_favored - 1 : pending_favored;
   }
 
   //munmap(orig_in, queue_cur->len);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -365,6 +365,7 @@ u32 *response_bytes = NULL; //an array keeping accumulated response buffer size
                             //e.g., response_bytes[i] keeps the response buffer size
                             //once messages 0->i have been received and processed by the SUT
 u32 max_annotated_regions = 0;
+u32 prev_target_state_id = -1;
 u32 target_state_id = 0;
 u32 *state_ids = NULL;
 u32 state_ids_count = 0;
@@ -2146,8 +2147,8 @@ static void cull_queue(void) {
   static u8 temp_v[MAP_SIZE >> 3];
   u32 i;
 
-  if (dumb_mode || !score_changed) return;
-
+  if ((dumb_mode || !score_changed) && (prev_target_state_id == target_state_id)) return;
+  prev_target_state_id = target_state_id;
   score_changed = 0;
 
   memset(temp_v, 255, MAP_SIZE >> 3);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2176,8 +2176,8 @@ static void cull_queue(void) {
       while (j--)
         if (top_rated[i]->trace_mini[j])
           temp_v[j] &= ~top_rated[i]->trace_mini[j];
-
-      top_rated[i]->favored = 1;
+      if (top_rated[i]->generating_state_id == target_state_id || top_rated[i]->is_initial_seed)
+        top_rated[i]->favored = 1;
       queued_favored++;
 
       //if (!top_rated[i]->was_fuzzed) pending_favored++;

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -2176,8 +2176,8 @@ static void cull_queue(void) {
       while (j--)
         if (top_rated[i]->trace_mini[j])
           temp_v[j] &= ~top_rated[i]->trace_mini[j];
-      if (top_rated[i]->generating_state_id == target_state_id || top_rated[i]->is_initial_seed)
-        top_rated[i]->favored = 1;
+
+      top_rated[i]->favored = 1;
       queued_favored++;
 
       //if (!top_rated[i]->was_fuzzed) pending_favored++;
@@ -7617,7 +7617,7 @@ abandon_entry:
     queue_cur->was_fuzzed = 1;
     was_fuzzed_map[get_state_index(target_state_id)][queue_cur->index] = 1;
     pending_not_fuzzed--;
-    if (queue_cur->favored) pending_favored--;
+    if (queue_cur->favored && (queue_cur->generating_state_id == target_state_id || queue_cur->is_initial_seed)) pending_favored--;
   }
 
   //munmap(orig_in, queue_cur->len);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7619,8 +7619,6 @@ abandon_entry:
     pending_not_fuzzed--;
     if (queue_cur->favored && (queue_cur->generating_state_id == target_state_id || queue_cur->is_initial_seed))
       pending_favored--;
-    else if (queue_cur->favored && queue_cur->generating_state_id != target_state_id)
-      pending_favored = (pending_favored > 0) ? pending_favored - 1 : pending_favored;
   }
 
   //munmap(orig_in, queue_cur->len);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7617,7 +7617,8 @@ abandon_entry:
     queue_cur->was_fuzzed = 1;
     was_fuzzed_map[get_state_index(target_state_id)][queue_cur->index] = 1;
     pending_not_fuzzed--;
-    if (queue_cur->favored && (queue_cur->generating_state_id == target_state_id || queue_cur->is_initial_seed)) pending_favored--;
+    if (queue_cur->favored && (queue_cur->generating_state_id == target_state_id || queue_cur->is_initial_seed))
+      pending_favored--;
   }
 
   //munmap(orig_in, queue_cur->len);


### PR DESCRIPTION
Hello, I'm Sangjun Park who is a master student and research Network Protocol Fuzz.

I found the many issue that had trouble with underflowing `pending_favored`

We should consider the case that is not originate from target_state_id(generating_state_id). however, it is in the target_state seed pool.
```
top_rated[i]->generating_state_id == target_state_id
```
If the seed unsatisfied written condition is chosen in choose_seed() stage and that test case is considered as a favored test case, this can cause a mismatching between the number of unfuzzed favored entries and the `pending_favored` count.

For example, let's assume that the seed is considered as favored, but the seed is not originated from `target_state_id`. Then current value of pending_favored will be 0.
Because this condition is not satisfied.
```
top_rated[i]->generating_state_id == target_state_id
```
ex) concrete value: seed->favored=1, but pending_favored=0;

If one of these entries is selected during the seed selection phase and goes through the mutation phase, the following line will execute after the havoc phase:
```
if (queue_cur->favored) pending_favored--;
```
This will cause an underflow, as pending_favored is already at 0.
```
if (!stop_soon && !queue_cur->cal_failed && !queue_cur->was_fuzzed) {
  queue_cur->was_fuzzed = 1;
  was_fuzzed_map[get_state_index(target_state_id)][queue_cur->index] = 1;
  pending_not_fuzzed--;
  if (queue_cur->favored) pending_favored--;
}
```

As a result, the fuzzer will stuck in this stage, when the pending_favored is overflowed and every chosen queue entry is queue_cur->was_fuzzed==1. This will persistent before fuzzer find new path and reset their pending_favored in `cull_queue()` and it can make the fuzzer more slow.
```
  if (pending_favored) {

    /* If we have any favored, non-fuzzed new arrivals in the queue,
       possibly skip to them at the expense of already-fuzzed or non-favored
       cases. */

    if ((queue_cur->was_fuzzed || !queue_cur->favored) &&
        UR(100) < SKIP_TO_NEW_PROB) return 1;

  }
```

I hope this patch will resolve the issue.

