### PR TITLE
AFLNet extension

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -479,6 +479,8 @@ void update_state_bitmap(){
   }
   state_sequence = (*extract_response_codes)(response_buf, response_buf_size, &state_count);
 
+  if(feedback_type != STATE_FEEDBACK && feedback_type != CODE_STATE_FEEDBACK) return;
+
   u32 prev_state = 0;
 
   for (u32 i = 0; i < state_count; i++) {
@@ -3308,7 +3310,7 @@ static u8 run_target(char** argv, u32 timeout) {
      compiler below this point. Past this location, trace_bits[] behave
      very normally and do not have to be treated as volatile. */
 
-  if (feedback_type == STATE_FEEDBACK || feedback_type == CODE_STATE_FEEDBACK) update_state_bitmap();
+  update_state_bitmap();
   MEM_BARRIER();
 
   tb4 = *(u32*)trace_bits;

--- a/aflnet.h
+++ b/aflnet.h
@@ -46,9 +46,16 @@ enum {
 
 enum {
   /* 00 */ INVALID_FEEDBACK,
-  /* 01 */ CODE_FEEDBACK,
-  /* 02 */ STATE_FEEDBACK,
-  /* 03 */ CODE_STATE_FEEDBACK,
+  /* 01 */ CODE_FEEDBACK,       // select interesting seeds based on code feedback
+  /* 02 */ STATE_FEEDBACK,      // select interesting seeds based on state feedback
+  /* 03 */ CODE_STATE_FEEDBACK, // select interesting seeds based on both feedback
+};
+
+enum {
+  /* 00 */ INVALID_SCHEDULE,
+  /* 01 */ QUEUE_SCHEDULE,   // choose next seeds based on seed queue
+  /* 02 */ IPSM_SCHEDULE,    // choose next seeds based on state machine
+  /* 03 */ HYBRID_SCHEDULE,  // choose next seeds based on state machine only when the fuzzer is stuck
 };
 
 // Initialize klist linked list data structure

--- a/aflnet.h
+++ b/aflnet.h
@@ -44,6 +44,13 @@ enum {
   /* 03 */ FAVOR
 };
 
+enum {
+  /* 00 */ INVALID_FEEDBACK,
+  /* 01 */ CODE_FEEDBACK,
+  /* 02 */ STATE_FEEDBACK,
+  /* 03 */ CODE_STATE_FEEDBACK,
+};
+
 // Initialize klist linked list data structure
 #define message_t_freer(x)
 KLIST_INIT(lms, message_t *, message_t_freer)
@@ -52,6 +59,9 @@ KHASH_SET_INIT_INT(hs32)
 
 // Initialize a hash table with int key and value is of type state_info_t
 KHASH_INIT(hms, khint32_t, state_info_t *, 1, kh_int_hash_func, kh_int_hash_equal)
+
+// Initialize a map with int key and u32 value
+KHASH_MAP_INIT_INT(32, u32)
 
 // Functions for extracting requests and responses
 
@@ -141,5 +151,9 @@ void hexdump(unsigned char *msg, unsigned char * buf, int start, int end);
 
 /* Reads a number of bytes from buf from offset into an unsigned int and returns it. May overflow*/
 u32 read_bytes_to_uint32(unsigned char* buf, unsigned int offset, int num_bytes);
+
+/* Mapping from original message code IDs to compact IDs starting from 1 */
+void init_message_code_map();
+void destroy_message_code_map();
 
 #endif /* __AFLNET_H */

--- a/config.h
+++ b/config.h
@@ -328,6 +328,12 @@
 #define MAP_SIZE_POW2       16
 #define MAP_SIZE            (1 << MAP_SIZE_POW2)
 
+/* Half for storing code coverage, and half for storing state coverage */
+#define SHIFT_SIZE          (1 << (MAP_SIZE_POW2 - 1))
+
+#define STATE_SIZE_POW2     8
+#define STATE_SIZE          (1 << STATE_SIZE_POW2)
+
 #define STATE_STR_LEN 12
 
 /* Maximum allocator request size (keep well under INT_MAX): */

--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -139,8 +139,15 @@ bool AFLCoverage::runOnModule(Module &M) {
 
       LoadInst *MapPtr = IRB.CreateLoad(AFLMapPtr);
       MapPtr->setMetadata(M.getMDKindID("nosanitize"), MDNode::get(C, None));
+      // Value *MapPtrIdx =
+      //     IRB.CreateGEP(MapPtr, IRB.CreateXor(PrevLocCasted, CurLoc));
+      /* Shift coverage feedback to the left by SHIFT_SIZE many elements
+        (PrevLocCasted XOR PrevLocCasted) -->
+        (((PrevLocCasted XOR PrevLocCasted) % (MAP_SIZE - SHIFT_SIZE)) + SHIFT_SIZE)
+      */
       Value *MapPtrIdx =
-          IRB.CreateGEP(MapPtr, IRB.CreateXor(PrevLocCasted, CurLoc));
+          IRB.CreateGEP(MapPtr,
+                        IRB.CreateAdd(IRB.CreateURem(IRB.CreateXor(PrevLocCasted, CurLoc), ConstantInt::get(Int32Ty, MAP_SIZE - SHIFT_SIZE)), ConstantInt::get(Int32Ty, SHIFT_SIZE)));
 
       /* Update bitmap */
 


### PR DESCRIPTION
There are two extensions for AFLNet:
1. Modify the strategy to select interesting seeds: 
   - Both code feedback and state feedback can be maintained into the same bitmap; 
   - Interesting seeds can be selected based on: (1) code feedback only; (2) state feedback only; or (3) both code and state feedback. 
   - A new option "-b" is used to configure this

2. Modify the strategy to choose the next seed:
   - The next seed to fuzz can be chosen based on: (1) the original seed queue; (2) the state machine; or (3) the state machine only when the fuzzer is stuck; otherwise it falls back to the original seed queue.
   - A new option "-h" is added to configure this